### PR TITLE
Enable wireless display support

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -142,3 +142,7 @@ PRODUCT_COPY_FILES += \
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/../taimen/ubuntu/display.conf:system/halium/etc/ubuntu-touch-session.d/android.conf
+
+# UT wireless display
+PRODUCT_PROPERTY_OVERRIDES += \
+    ubuntu.widi.supported=1


### PR DESCRIPTION
Tested on Pixel 2 XL and a cheapo adapter - works great. Probably works on the base 2 too but I don't have one to test.